### PR TITLE
Add Avalon-style macro preferences UI with default bindings

### DIFF
--- a/app/src/Outlander.xcodeproj/project.pbxproj
+++ b/app/src/Outlander.xcodeproj/project.pbxproj
@@ -32,6 +32,16 @@
 		7B10A6982763468C000FEDE8 /* WindowSettings.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7B10A6962763468C000FEDE8 /* WindowSettings.storyboard */; };
 		7B10A69A276346C9000FEDE8 /* WindowSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B10A699276346C9000FEDE8 /* WindowSettingsViewController.swift */; };
 		7B10A69B276346C9000FEDE8 /* WindowSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B10A699276346C9000FEDE8 /* WindowSettingsViewController.swift */; };
+		7B35B1D52C1DA3E9000C5C1F /* MacroPreferencesCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B35B1D42C1DA3E9000C5C1F /* MacroPreferencesCoordinator.swift */; };
+		7B35B1D62C1DA3E9000C5C1F /* MacroPreferencesCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B35B1D42C1DA3E9000C5C1F /* MacroPreferencesCoordinator.swift */; };
+		7B35B1F12C1DB240000C5C1F /* MacroPreferencesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B35B1F02C1DB240000C5C1F /* MacroPreferencesModel.swift */; };
+		7B35B1F22C1DB240000C5C1F /* MacroPreferencesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B35B1F02C1DB240000C5C1F /* MacroPreferencesModel.swift */; };
+		7B35B1F42C1DB240000C5C1F /* MacroPreferencesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B35B1F32C1DB240000C5C1F /* MacroPreferencesViewController.swift */; };
+		7B35B1F52C1DB240000C5C1F /* MacroPreferencesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B35B1F32C1DB240000C5C1F /* MacroPreferencesViewController.swift */; };
+		7B35B1F72C1DB240000C5C1F /* GameContext+Macros.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B35B1F62C1DB240000C5C1F /* GameContext+Macros.swift */; };
+		7B35B1F82C1DB240000C5C1F /* GameContext+Macros.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B35B1F62C1DB240000C5C1F /* GameContext+Macros.swift */; };
+		7B35B2062C1DCA58000C5C1F /* MacroDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B35B2052C1DCA58000C5C1F /* MacroDefaults.swift */; };
+		7B35B2072C1DCA58000C5C1F /* MacroDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B35B2052C1DCA58000C5C1F /* MacroDefaults.swift */; };
 		7B228AF927277BBA0052610B /* SendCommandHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B228AF827277BBA0052610B /* SendCommandHandler.swift */; };
 		7B228AFA272795920052610B /* SendCommandHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B228AF827277BBA0052610B /* SendCommandHandler.swift */; };
 		7B228AFC2728BBB30052610B /* StatusBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B228AFB2728BBB30052610B /* StatusBarViewController.swift */; };
@@ -335,6 +345,11 @@
 		7B10A693275FFA25000FEDE8 /* EvalCommandHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvalCommandHandler.swift; sourceTree = "<group>"; };
 		7B10A6962763468C000FEDE8 /* WindowSettings.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = WindowSettings.storyboard; sourceTree = "<group>"; };
 		7B10A699276346C9000FEDE8 /* WindowSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowSettingsViewController.swift; sourceTree = "<group>"; };
+		7B35B1D42C1DA3E9000C5C1F /* MacroPreferencesCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacroPreferencesCoordinator.swift; sourceTree = "<group>"; };
+		7B35B1F02C1DB240000C5C1F /* MacroPreferencesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacroPreferencesModel.swift; sourceTree = "<group>"; };
+		7B35B1F32C1DB240000C5C1F /* MacroPreferencesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacroPreferencesViewController.swift; sourceTree = "<group>"; };
+		7B35B1F62C1DB240000C5C1F /* GameContext+Macros.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GameContext+Macros.swift"; sourceTree = "<group>"; };
+		7B35B2052C1DCA58000C5C1F /* MacroDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacroDefaults.swift; sourceTree = "<group>"; };
 		7B228AF827277BBA0052610B /* SendCommandHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendCommandHandler.swift; sourceTree = "<group>"; };
 		7B228AFB2728BBB30052610B /* StatusBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarViewController.swift; sourceTree = "<group>"; };
 		7B228B002728C1670052610B /* StatusBar.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = StatusBar.storyboard; sourceTree = "<group>"; };
@@ -657,6 +672,8 @@
 				7BBBC517276DA3E400D1CF3E /* LogBuilder.swift */,
 				F98B492B2471F38E000E2D92 /* Logger.swift */,
 				7BDF5C87272736300020A3B0 /* MacroExtensions.swift */,
+				7B35B2052C1DCA58000C5C1F /* MacroDefaults.swift */,
+				7B35B1F62C1DB240000C5C1F /* GameContext+Macros.swift */,
 				F9D36E8E22EAE326008BC6E6 /* NSColorExtensions.swift */,
 				7B228B28273B09D70052610B /* NSViewExtensions.swift */,
 				F9BCF32322E28F2400C7F7F0 /* Regex.swift */,
@@ -699,6 +716,9 @@
 				F969A0E7239C7F9B00408CE5 /* Window.storyboard */,
 				F969A0EA239C812900408CE5 /* WindowViewController.swift */,
 				7B10A699276346C9000FEDE8 /* WindowSettingsViewController.swift */,
+				7B35B1D42C1DA3E9000C5C1F /* MacroPreferencesCoordinator.swift */,
+				7B35B1F02C1DB240000C5C1F /* MacroPreferencesModel.swift */,
+				7B35B1F32C1DB240000C5C1F /* MacroPreferencesViewController.swift */,
 				7B10A6962763468C000FEDE8 /* WindowSettings.storyboard */,
 			);
 			path = UI;
@@ -1016,6 +1036,7 @@
 				F98B49262470F685000E2D92 /* Events.swift in Sources */,
 				7B3B9A1A2759DB200035D731 /* IconLoader.swift in Sources */,
 				7BDF5C88272736300020A3B0 /* MacroExtensions.swift in Sources */,
+				7B35B2062C1DCA58000C5C1F /* MacroDefaults.swift in Sources */,
 				7BCBBD0F2743ABEA00219CA0 /* VariableTokenizer.swift in Sources */,
 				7BA27B5025DF93C500A88B80 /* Combinators.swift in Sources */,
 				7B10A672275D7F37000FEDE8 /* OWindow.swift in Sources */,
@@ -1039,6 +1060,10 @@
 				7BA27B3725DF6D9D00A88B80 /* Script.swift in Sources */,
 				F9BCF31E22E28EC200C7F7F0 /* Socket.swift in Sources */,
 				7B10A69A276346C9000FEDE8 /* WindowSettingsViewController.swift in Sources */,
+				7B35B1D52C1DA3E9000C5C1F /* MacroPreferencesCoordinator.swift in Sources */,
+				7B35B1F12C1DB240000C5C1F /* MacroPreferencesModel.swift in Sources */,
+				7B35B1F42C1DB240000C5C1F /* MacroPreferencesViewController.swift in Sources */,
+				7B35B1F72C1DB240000C5C1F /* GameContext+Macros.swift in Sources */,
 				7B228AF927277BBA0052610B /* SendCommandHandler.swift in Sources */,
 				7B917E5C27641E5300887F95 /* SimplePing.m in Sources */,
 				7B10A68E275FE538000FEDE8 /* HighlightsCommandHandler.swift in Sources */,
@@ -1173,6 +1198,11 @@
 				7B228B1E273871720052610B /* Pathfinder.swift in Sources */,
 				F98B4907246F8EFD000E2D92 /* AliasLoader.swift in Sources */,
 				7B10A69B276346C9000FEDE8 /* WindowSettingsViewController.swift in Sources */,
+				7B35B1D62C1DA3E9000C5C1F /* MacroPreferencesCoordinator.swift in Sources */,
+				7B35B1F22C1DB240000C5C1F /* MacroPreferencesModel.swift in Sources */,
+				7B35B1F52C1DB240000C5C1F /* MacroPreferencesViewController.swift in Sources */,
+				7B35B1F82C1DB240000C5C1F /* GameContext+Macros.swift in Sources */,
+				7B35B2072C1DCA58000C5C1F /* MacroDefaults.swift in Sources */,
 				F98B4911246FA149000E2D92 /* SubstituteLoaderTests.swift in Sources */,
 				7B3B9A1B2759DB200035D731 /* IconLoader.swift in Sources */,
 				7B0A8AAC296A14DD0036C5BF /* ApplicationVersion.swift in Sources */,
@@ -1445,12 +1475,13 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Outlander/Outlander.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 53;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = 9TZ225FMST;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "";
@@ -1481,11 +1512,12 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Outlander/Outlander.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 53;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = 9TZ225FMST;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "";

--- a/app/src/Outlander.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/src/Outlander.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,25 +1,60 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "CocoaAsyncSocket",
-        "repositoryURL": "https://github.com/robbiehanson/CocoaAsyncSocket",
-        "state": {
-          "branch": null,
-          "revision": "0e00c967a010fc43ce528bd633d032f17158d393",
-          "version": "7.6.4"
-        }
-      },
-      {
-        "package": "Fuzi",
-        "repositoryURL": "https://github.com/cezheng/Fuzi",
-        "state": {
-          "branch": null,
-          "revision": "f08c8323da21e985f3772610753bcfc652c2103f",
-          "version": "3.1.3"
-        }
+  "originHash" : "0c99fa19a6ee5b37bbb31f704e3a02a900a633cb3bcee90055c50826500000e6",
+  "pins" : [
+    {
+      "identity" : "cocoaasyncsocket",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/robbiehanson/CocoaAsyncSocket",
+      "state" : {
+        "revision" : "dbdc00669c1ced63b27c3c5f052ee4d28f10150c",
+        "version" : "7.6.5"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "expression",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nicklockwood/Expression",
+      "state" : {
+        "revision" : "95ffe4c352e456cede933d9910d25b9c84039d1b",
+        "version" : "0.13.9"
+      }
+    },
+    {
+      "identity" : "fuzi",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/cezheng/Fuzi",
+      "state" : {
+        "revision" : "f08c8323da21e985f3772610753bcfc652c2103f",
+        "version" : "3.1.3"
+      }
+    },
+    {
+      "identity" : "keychain-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/evgenyneu/keychain-swift.git",
+      "state" : {
+        "revision" : "96fb84f45a96630e7583903bd7e08cf095c7a7ef",
+        "version" : "19.0.0"
+      }
+    },
+    {
+      "identity" : "plugin-package",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/outlander-app/plugin-package.git",
+      "state" : {
+        "revision" : "b48163e08d834a6d6eb6649fc6e33a236bd3deab",
+        "version" : "1.0.5"
+      }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "branch" : "2.x",
+        "revision" : "70b82ce304f7dec9bd120b174819812ca2b8d8f0"
+      }
+    }
+  ],
+  "version" : 3
 }

--- a/app/src/Outlander/AppDelegate.swift
+++ b/app/src/Outlander/AppDelegate.swift
@@ -14,6 +14,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 //    let updaterController: SPUStandardUpdaterController
     var windows: [NSWindow] = []
     var rootUrl: URL?
+    private lazy var macroPreferencesCoordinator = MacroPreferencesCoordinator { [weak self] in
+        self?.activeController?.gameContext
+    }
 
     override init() {
 //        updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
@@ -129,6 +132,27 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @IBAction func showWindowSettings(_: Any) {
         sendCommand("layout:Settings")
+    }
+
+    @IBAction func showHighlightsPreferences(_: Any) {
+        let alert = NSAlert()
+        alert.messageText = "Highlights preferences are not available yet."
+        alert.informativeText = "Highlight management will be added in a future update."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+
+    @IBAction func showAZMacros(_: Any) {
+        macroPreferencesCoordinator.showWindow(for: .letters)
+    }
+
+    @IBAction func showKeypadMacros(_: Any) {
+        macroPreferencesCoordinator.showWindow(for: .keypad)
+    }
+
+    @IBAction func showFunctionMacros(_: Any) {
+        macroPreferencesCoordinator.showWindow(for: .function)
     }
 
     @IBAction func chooseSettingsDirectoryAction(_: Any) {

--- a/app/src/Outlander/Infrastructure/GameContext+Macros.swift
+++ b/app/src/Outlander/Infrastructure/GameContext+Macros.swift
@@ -1,0 +1,42 @@
+//
+//  GameContext+Macros.swift
+//  Outlander
+//
+//  Created by Codex on 5/18/25.
+//
+
+import Cocoa
+
+extension Macro {
+    func matches(key: Key, modifiers: NSEvent.ModifierFlags) -> Bool {
+        carbonKeyCode == key.rawValue && self.modifiers == modifiers
+    }
+}
+
+extension GameContext {
+    func macroAction(for key: Key, modifiers: NSEvent.ModifierFlags) -> String? {
+        macroEntry(for: key, modifiers: modifiers)?.macro.action
+    }
+
+    func setMacro(action: String?, for key: Key, modifiers: NSEvent.ModifierFlags) {
+        let normalized = action?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if let entry = macroEntry(for: key, modifiers: modifiers) {
+            macros.removeValue(forKey: entry.identifier)
+        }
+
+        guard let normalized, !normalized.isEmpty else {
+            return
+        }
+
+        let macro = Macro(key: key, modifiers: modifiers, action: normalized)
+        macros[macro.description] = macro
+    }
+
+    private func macroEntry(for key: Key, modifiers: NSEvent.ModifierFlags) -> (identifier: String, macro: Macro)? {
+        for (identifier, macro) in macros where macro.matches(key: key, modifiers: modifiers) {
+            return (identifier, macro)
+        }
+        return nil
+    }
+}

--- a/app/src/Outlander/Infrastructure/MacroDefaults.swift
+++ b/app/src/Outlander/Infrastructure/MacroDefaults.swift
@@ -1,0 +1,88 @@
+//
+//  MacroDefaults.swift
+//  Outlander
+//
+//  Created by Codex on 5/18/25.
+//
+
+import Cocoa
+
+struct MacroDefaultEntry {
+    let key: Key
+    let modifiers: NSEvent.ModifierFlags
+    let action: String
+}
+
+enum MacroDefaults {
+    static let entries: [MacroDefaultEntry] = {
+        var list: [MacroDefaultEntry] = []
+
+        func add(_ key: Key, _ modifiers: NSEvent.ModifierFlags = [], _ action: String) {
+            list.append(MacroDefaultEntry(key: key, modifiers: modifiers, action: action))
+        }
+
+        // Base keypad navigation (no modifier)
+        add(.keypadMultiply, [], "exp")
+        add(.keypadPlus, [], "look")
+        add(.keypadDecimal, [], "up")
+        add(.keypadDivide, [], "health")
+        add(.keypad0, [], "down")
+        add(.keypad1, [], "southwest")
+        add(.keypad2, [], "south")
+        add(.keypad3, [], "southeast")
+        add(.keypad4, [], "west")
+        add(.keypad5, [], "out")
+        add(.keypad6, [], "east")
+        add(.keypad7, [], "northwest")
+        add(.keypad8, [], "north")
+        add(.keypad9, [], "northeast")
+
+        // Command keypad (sneak)
+        add(.keypadDecimal, [.command], "sneak up")
+        add(.keypad0, [.command], "sneak down")
+        add(.keypad1, [.command], "sneak southwest")
+        add(.keypad2, [.command], "sneak south")
+        add(.keypad3, [.command], "sneak southeast")
+        add(.keypad4, [.command], "sneak west")
+        add(.keypad5, [.command], "sneak out")
+        add(.keypad6, [.command], "sneak east")
+        add(.keypad7, [.command], "sneak northwest")
+        add(.keypad8, [.command], "sneak north")
+        add(.keypad9, [.command], "sneak northeast")
+
+        // Control keypad (familiar)
+        add(.keypadPlus, [.control], "tell familiar to look")
+        add(.keypadDecimal, [.control], "tell familiar to go up")
+        add(.keypad0, [.control], "tell familiar to go down")
+        add(.keypad1, [.control], "tell familiar to go southwest")
+        add(.keypad2, [.control], "tell familiar to go south")
+        add(.keypad3, [.control], "tell familiar to go southeast")
+        add(.keypad4, [.control], "tell familiar to go west")
+        add(.keypad5, [.control], "tell familiar to go out")
+        add(.keypad6, [.control], "tell familiar to go east")
+        add(.keypad7, [.control], "tell familiar to go northwest")
+        add(.keypad8, [.control], "tell familiar to go north")
+        add(.keypad9, [.control], "tell familiar to go northeast")
+
+        // Function defaults
+        add(.escape, [], "clear")
+
+        return list
+    }()
+
+    static func defaultMacros() -> [Macro] {
+        entries.map { Macro(key: $0.key, modifiers: $0.modifiers, action: $0.action) }
+    }
+
+    static func valuesByModifierRaw(filteredBy keys: Set<Key>) -> [UInt: [Key: String]] {
+        var result: [UInt: [Key: String]] = [:]
+        for entry in entries where keys.contains(entry.key) {
+            let raw = entry.modifiers.rawValue
+            if result[raw] == nil {
+                result[raw] = [:]
+            }
+            result[raw]?[entry.key] = entry.action
+        }
+        return result
+    }
+}

--- a/app/src/Outlander/MainMenu.xib
+++ b/app/src/Outlander/MainMenu.xib
@@ -28,10 +28,47 @@
                                     <action selector="chooseSettingsDirectoryAction:" target="-1" id="tql-lx-flc"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW">
-                                <connections>
-                                    <action selector="preferences:" target="-1" id="VGP-Vt-cDj"/>
-                                </connections>
+                            <menuItem title="Settings..." id="BOF-NM-1cW">
+                                <menu key="submenu" title="Settings" id="xSt-ZH-w0h">
+                                    <items>
+                                        <menuItem title="General Preferences…" keyEquivalent="," id="G8h-Tm-Gen">
+                                            <connections>
+                                                <action selector="preferences:" target="-1" id="VGP-Vt-cDj"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Highlights..." id="r9N-WC-hiL">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="showHighlightsPreferences:" target="-1" id="8rG-0J-l2P"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Macros" id="e7L-sH-mCr">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Macros" id="r2H-8V-mac">
+                                                <items>
+                                                    <menuItem title="A–Z Macros" id="hbU-az-001">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="showAZMacros:" target="-1" id="9kW-yY-apw"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Keypad Macros" id="hbU-az-002">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="showKeypadMacros:" target="-1" id="I0b-vq-ElS"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Function Macros" id="hbU-az-003">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="showFunctionMacros:" target="-1" id="9q0-wb-w0N"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                    </items>
+                                </menu>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="hUx-y0-UNZ"/>
                             <menuItem title="Check for Updates..." id="DxX-pv-pyI">

--- a/app/src/Outlander/Settings/MacroLoader.swift
+++ b/app/src/Outlander/Settings/MacroLoader.swift
@@ -345,15 +345,12 @@ class MacroLoader {
     func load(_ settings: ApplicationSettings, context: GameContext) {
         let fileUrl = settings.currentProfilePath.appendingPathComponent(filename)
 
-        guard let data = files.load(fileUrl) else {
-            return
-        }
-
-        guard let content = String(data: data, encoding: .utf8) else {
-            return
-        }
-
         context.macros.removeAll()
+
+        guard let data = files.load(fileUrl), let content = String(data: data, encoding: .utf8) else {
+            applyDefaults(context: context, settings: settings)
+            return
+        }
 
         for var line in content.components(separatedBy: .newlines) {
             guard !line.isEmpty else {
@@ -364,6 +361,10 @@ class MacroLoader {
             } else {
                 context.events2.echoError("Invalid macro: \(line)")
             }
+        }
+
+        if context.macros.isEmpty {
+            applyDefaults(context: context, settings: settings)
         }
     }
 
@@ -379,6 +380,14 @@ class MacroLoader {
         }
 
         files.write(content, to: fileUrl)
+    }
+
+    private func applyDefaults(context: GameContext, settings: ApplicationSettings) {
+        let defaults = MacroDefaults.defaultMacros()
+        for macro in defaults {
+            context.macros[macro.description] = macro
+        }
+        save(settings, macros: context.macros)
     }
 }
 

--- a/app/src/Outlander/UI/MacroPreferencesCoordinator.swift
+++ b/app/src/Outlander/UI/MacroPreferencesCoordinator.swift
@@ -1,0 +1,96 @@
+//
+//  MacroPreferencesCoordinator.swift
+//  Outlander
+//
+//  Created by Codex on 5/18/25.
+//
+
+import Cocoa
+
+enum MacroPreferencesCategory: String, CaseIterable {
+    case letters = "A–Z Macros"
+    case keypad = "Keypad Macros"
+    case function = "Function Macros"
+
+    var title: String { rawValue }
+}
+
+final class MacroPreferencesCoordinator {
+    private let contextProvider: () -> GameContext?
+    private var controllers: [MacroPreferencesCategory: MacroPreferencesWindowController] = [:]
+
+    init(contextProvider: @escaping () -> GameContext?) {
+        self.contextProvider = contextProvider
+    }
+
+    func showWindow(for category: MacroPreferencesCategory) {
+        guard let context = contextProvider() else {
+            presentNoContextAlert()
+            return
+        }
+
+        let controller = controller(for: category)
+        controller.updateContext(context)
+        controller.showWindow(self)
+        controller.window?.makeKeyAndOrderFront(self)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    private func controller(for category: MacroPreferencesCategory) -> MacroPreferencesWindowController {
+        if let existing = controllers[category] {
+            return existing
+        }
+
+        let controller = MacroPreferencesWindowController(category: category)
+        controllers[category] = controller
+        return controller
+    }
+
+    private func presentNoContextAlert() {
+        let alert = NSAlert()
+        alert.messageText = "No active game window"
+        alert.informativeText = "Open or select a game window before editing macros."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+}
+
+final class MacroPreferencesWindowController: NSWindowController {
+    private let category: MacroPreferencesCategory
+    private let macroViewController: MacroPreferencesViewController
+
+    init(category: MacroPreferencesCategory) {
+        self.category = category
+        self.macroViewController = MacroPreferencesViewController(category: category)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 560, height: 420),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = category.title
+        window.isReleasedWhenClosed = false
+        window.minSize = NSSize(width: 520, height: 360)
+
+        super.init(window: window)
+
+        window.contentViewController = macroViewController
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func windowDidLoad() {
+        super.windowDidLoad()
+        guard let window else { return }
+        window.center()
+    }
+
+    func updateContext(_ context: GameContext) {
+        macroViewController.updateContext(context)
+    }
+}

--- a/app/src/Outlander/UI/MacroPreferencesModel.swift
+++ b/app/src/Outlander/UI/MacroPreferencesModel.swift
@@ -1,0 +1,287 @@
+//
+//  MacroPreferencesModel.swift
+//  Outlander
+//
+//  Created by Codex on 5/18/25.
+//
+
+import Carbon.HIToolbox
+import Cocoa
+
+struct MacroKeyDefinition: Hashable {
+    let title: String
+    let key: Key
+}
+
+enum MacroModifierGroup: Hashable {
+    case none
+    case command
+    case option
+    case control
+    case shift
+
+    var title: String {
+        switch self {
+        case .none: "None"
+        case .command: "Command"
+        case .option: "Option"
+        case .control: "Control"
+        case .shift: "Shift"
+        }
+    }
+
+    var flags: NSEvent.ModifierFlags {
+        switch self {
+        case .none: []
+        case .command: [.command]
+        case .option: [.option]
+        case .control: [.control]
+        case .shift: [.shift]
+        }
+    }
+
+    static func group(for flags: NSEvent.ModifierFlags) -> MacroModifierGroup? {
+        if flags.isEmpty {
+            return .none
+        }
+        switch flags {
+        case [.command]:
+            return .command
+        case [.option]:
+            return .option
+        case [.control]:
+            return .control
+        case [.shift]:
+            return .shift
+        default:
+            return nil
+        }
+    }
+
+    static func groups(for category: MacroPreferencesCategory) -> [MacroModifierGroup] {
+        switch category {
+        case .letters:
+            return [.command, .option, .control]
+        case .keypad, .function:
+            return [.none, .command, .option, .control, .shift]
+        }
+    }
+}
+
+struct MacroPreferencesStore {
+    private(set) var values: [MacroModifierGroup: [Key: String]] = [:]
+    private let reserved: [MacroModifierGroup: [Key: String]]
+    let keyDefinitions: [MacroKeyDefinition]
+    let modifierGroups: [MacroModifierGroup]
+
+    init(category: MacroPreferencesCategory, context: GameContext?) {
+        self.keyDefinitions = MacroPreferencesStore.buildKeyDefinitions(for: category)
+        self.modifierGroups = MacroModifierGroup.groups(for: category)
+
+        let defaults = MacroPreferencesStore.defaultValues(for: category)
+        self.reserved = MacroPreferencesStore.reservedKeys(for: category)
+
+        for group in modifierGroups {
+            var entries: [Key: String] = [:]
+
+            for definition in keyDefinitions {
+                if reserved[group]?[definition.key] != nil {
+                    continue
+                }
+                let existing = context?.macroAction(for: definition.key, modifiers: group.flags)
+                let fallback = defaults[group]?[definition.key]
+                entries[definition.key] = existing ?? fallback ?? ""
+            }
+
+            values[group] = entries
+        }
+    }
+
+    func value(for group: MacroModifierGroup, key: Key) -> String {
+        values[group]?[key] ?? ""
+    }
+
+    mutating func setValue(_ value: String, for group: MacroModifierGroup, key: Key) {
+        guard values[group] != nil else {
+            return
+        }
+        guard reserved[group]?[key] == nil else {
+            return
+        }
+        values[group]?[key] = value
+    }
+
+    func isReserved(group: MacroModifierGroup, key: Key) -> Bool {
+        reserved[group]?[key] != nil
+    }
+
+    func reservedLabel(group: MacroModifierGroup, key: Key) -> String? {
+        reserved[group]?[key]
+    }
+
+    private static func buildKeyDefinitions(for category: MacroPreferencesCategory) -> [MacroKeyDefinition] {
+        switch category {
+        case .letters:
+            return MacroPreferencesStore.letterKeys()
+        case .keypad:
+            return MacroPreferencesStore.keypadKeys()
+        case .function:
+            return MacroPreferencesStore.functionKeys()
+        }
+    }
+
+    private static func letterKeys() -> [MacroKeyDefinition] {
+        let pairs: [(String, Key)] = [
+            ("A", .a), ("B", .b), ("C", .c), ("D", .d), ("E", .e), ("F", .f),
+            ("G", .g), ("H", .h), ("I", .i), ("J", .j), ("K", .k), ("L", .l),
+            ("M", .m), ("N", .n), ("O", .o), ("P", .p), ("Q", .q), ("R", .r),
+            ("S", .s), ("T", .t), ("U", .u), ("V", .v), ("W", .w), ("X", .x),
+            ("Y", .y), ("Z", .z),
+        ]
+
+        return pairs.map { MacroKeyDefinition(title: $0.0, key: $0.1) }
+    }
+
+    private static func keypadKeys() -> [MacroKeyDefinition] {
+        let pairs: [(String, Key)] = [
+            ("+", .keypadPlus),
+            ("-", .keypadMinus),
+            ("*", .keypadMultiply),
+            ("/", .keypadDivide),
+            ("=", .keypadEquals),
+            ("Clear", .keypadClear),
+            (".", .keypadDecimal),
+            ("0", .keypad0),
+            ("1", .keypad1),
+            ("2", .keypad2),
+            ("3", .keypad3),
+            ("4", .keypad4),
+            ("5", .keypad5),
+            ("6", .keypad6),
+            ("7", .keypad7),
+            ("8", .keypad8),
+            ("9", .keypad9),
+        ]
+
+        return pairs.map { MacroKeyDefinition(title: $0.0, key: $0.1) }
+    }
+
+    private static func functionKeys() -> [MacroKeyDefinition] {
+        let pairs: [(String, Key)] = [
+            ("Esc", .escape),
+            ("F1", .f1),
+            ("F2", .f2),
+            ("F3", .f3),
+            ("F4", .f4),
+            ("F5", .f5),
+            ("F6", .f6),
+            ("F7", .f7),
+            ("F8", .f8),
+            ("F9", .f9),
+            ("F10", .f10),
+            ("F11", .f11),
+            ("F12", .f12),
+        ]
+
+        return pairs.map { MacroKeyDefinition(title: $0.0, key: $0.1) }
+    }
+
+    private static func defaultValues(for category: MacroPreferencesCategory) -> [MacroModifierGroup: [Key: String]] {
+        let allowedKeys = Set(buildKeyDefinitions(for: category).map { $0.key })
+        let rawValues = MacroDefaults.valuesByModifierRaw(filteredBy: allowedKeys)
+        var result: [MacroModifierGroup: [Key: String]] = [:]
+
+        for (rawFlags, mapping) in rawValues {
+            let flags = NSEvent.ModifierFlags(rawValue: rawFlags)
+            guard let group = MacroModifierGroup.group(for: flags) else { continue }
+            guard MacroModifierGroup.groups(for: category).contains(group) else { continue }
+            guard !mapping.isEmpty else { continue }
+            result[group] = mapping
+        }
+
+        return result
+    }
+
+    private static func reservedKeys(for category: MacroPreferencesCategory) -> [MacroModifierGroup: [Key: String]] {
+        switch category {
+        case .letters:
+            let reservedKeys: Set<Key> = [.a, .c, .d, .e, .f, .g, .h, .i, .j, .q, .u, .v, .w, .x, .z]
+            let label = "Reserved"
+            return [.command: Dictionary(uniqueKeysWithValues: reservedKeys.map { ($0, label) })]
+        case .keypad:
+            return [:]
+        case .function:
+            let controlReserved: [Key: String] = [
+                .f1: "System Reserved",
+                .f2: "System Reserved",
+                .f4: "System Reserved",
+                .f5: "System Reserved",
+                .f6: "System Reserved",
+                .f7: "System Reserved",
+            ]
+            return [.control: controlReserved]
+        }
+    }
+
+    private static func defaultKeypadMacros() -> [MacroModifierGroup: [Key: String]] {
+        let baseDirections: [Key: String] = {
+            var map: [Key: String] = [:]
+            map[.keypad0] = "down"
+            map[.keypad1] = "southwest"
+            map[.keypad2] = "south"
+            map[.keypad3] = "southeast"
+            map[.keypad4] = "west"
+            map[.keypad5] = "out"
+            map[.keypad6] = "east"
+            map[.keypad7] = "northwest"
+            map[.keypad8] = "north"
+            map[.keypad9] = "northeast"
+            return map
+        }()
+
+        let noneGroup: [Key: String] = {
+            var map: [Key: String] = [:]
+            map[.keypadMultiply] = "exp"
+            map[.keypadPlus] = "look"
+            map[.keypadDecimal] = "up"
+            map[.keypadDivide] = "health"
+            for (key, direction) in baseDirections {
+                map[key] = direction
+            }
+            return map
+        }()
+
+        let commandGroup: [Key: String] = {
+            var map: [Key: String] = [:]
+            map[.keypadDecimal] = "sneak up"
+            map[.keypad0] = "sneak down"
+            for (key, direction) in baseDirections where key != .keypad0 {
+                map[key] = "sneak \(direction)"
+            }
+            return map
+        }()
+
+        let familiarGroup: [Key: String] = {
+            var map: [Key: String] = [:]
+            map[.keypadPlus] = "tell familiar to look"
+            map[.keypadDecimal] = "tell familiar to go up"
+            map[.keypad0] = "tell familiar to go down"
+            for (key, direction) in baseDirections {
+                map[key] = "tell familiar to go \(direction)"
+            }
+            return map
+        }()
+
+        return [
+            .none: noneGroup,
+            .command: commandGroup,
+            .control: familiarGroup,
+        ]
+    }
+
+    private static func defaultFunctionMacros() -> [MacroModifierGroup: [Key: String]] {
+        var map: [Key: String] = [:]
+        map[.escape] = "clear"
+        return [.none: map]
+    }
+}

--- a/app/src/Outlander/UI/MacroPreferencesViewController.swift
+++ b/app/src/Outlander/UI/MacroPreferencesViewController.swift
@@ -1,0 +1,338 @@
+//
+//  MacroPreferencesViewController.swift
+//  Outlander
+//
+//  Created by Codex on 5/18/25.
+//
+
+import Cocoa
+
+final class MacroPreferencesViewController: NSViewController, NSTableViewDataSource, NSTableViewDelegate, NSTextFieldDelegate {
+    private let category: MacroPreferencesCategory
+    private var store: MacroPreferencesStore?
+    private var context: GameContext?
+    private var currentGroup: MacroModifierGroup
+
+    // MARK: - UI
+
+    private let segmentedControl: NSSegmentedControl
+    private let tableView = NSTableView()
+    private let scrollView = NSScrollView()
+    private let footerLabel: NSTextField = {
+        let label = NSTextField(labelWithString: "")
+        label.isHidden = true
+        return label
+    }()
+    private let infoLabel: NSTextField = {
+        let label = NSTextField(labelWithString: "Open a game window to edit macros.")
+        label.font = NSFont.systemFont(ofSize: 14)
+        label.textColor = NSColor.secondaryLabelColor
+        label.alignment = .center
+        label.isHidden = true
+        return label
+    }()
+    private var macroSetPopup: NSPopUpButton?
+    private lazy var okButton: NSButton = {
+        let button = NSButton(title: "OK", target: self, action: #selector(saveAndClose))
+        button.keyEquivalent = "\r"
+        return button
+    }()
+    private lazy var cancelButton: NSButton = {
+        let button = NSButton(title: "Cancel", target: self, action: #selector(cancel))
+        button.keyEquivalent = "\u{1b}"
+        return button
+    }()
+
+    private let keyColumnIdentifier = NSUserInterfaceItemIdentifier("key")
+    private let macroColumnIdentifier = NSUserInterfaceItemIdentifier("macro")
+
+    init(category: MacroPreferencesCategory) {
+        self.category = category
+        let modifierGroups = MacroModifierGroup.groups(for: category)
+        let labels = modifierGroups.map(\.title)
+        self.currentGroup = modifierGroups.first ?? .command
+        self.segmentedControl = NSSegmentedControl(labels: labels, trackingMode: .selectOne, target: nil, action: nil)
+        super.init(nibName: nil, bundle: nil)
+        self.segmentedControl.target = self
+        self.segmentedControl.action = #selector(modifierChanged(_:))
+        self.segmentedControl.translatesAutoresizingMaskIntoConstraints = false
+        self.segmentedControl.segmentStyle = .automatic
+        self.segmentedControl.selectedSegment = labels.isEmpty ? -1 : 0
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+        view = NSView(frame: NSRect(x: 0, y: 0, width: 560, height: 420))
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+    }
+
+    override func viewDidAppear() {
+        super.viewDidAppear()
+        if let cell = okButton.cell as? NSButtonCell {
+            view.window?.defaultButtonCell = cell
+        }
+    }
+
+    func updateContext(_ context: GameContext) {
+        self.context = context
+        self.store = MacroPreferencesStore(category: category, context: context)
+        self.infoLabel.isHidden = true
+        reloadData()
+    }
+
+    // MARK: - Table Data
+
+    private var keyDefinitions: [MacroKeyDefinition] {
+        store?.keyDefinitions ?? []
+    }
+
+    private var modifierGroups: [MacroModifierGroup] {
+        store?.modifierGroups ?? MacroModifierGroup.groups(for: category)
+    }
+
+    private func reloadData() {
+        guard let store else {
+            segmentedControl.isEnabled = false
+            infoLabel.isHidden = false
+            tableView.reloadData()
+            return
+        }
+
+        segmentedControl.isEnabled = !store.modifierGroups.isEmpty
+        if segmentedControl.selectedSegment < 0, !store.modifierGroups.isEmpty {
+            segmentedControl.selectedSegment = 0
+            currentGroup = store.modifierGroups[0]
+        } else if segmentedControl.selectedSegment < store.modifierGroups.count {
+            currentGroup = store.modifierGroups[segmentedControl.selectedSegment]
+        }
+
+        tableView.reloadData()
+    }
+
+    // MARK: - Actions
+
+    @objc private func modifierChanged(_ sender: NSSegmentedControl) {
+        guard sender.selectedSegment >= 0 else { return }
+        let groups = modifierGroups
+        guard sender.selectedSegment < groups.count else { return }
+        currentGroup = groups[sender.selectedSegment]
+        tableView.reloadData()
+    }
+
+    @objc private func saveAndClose() {
+        guard let context, var store else {
+            view.window?.close()
+            return
+        }
+
+        for group in store.modifierGroups {
+            let flags = group.flags
+            for definition in store.keyDefinitions {
+                if store.isReserved(group: group, key: definition.key) {
+                    continue
+                }
+                let rawValue = store.value(for: group, key: definition.key)
+                let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                context.setMacro(action: trimmed.isEmpty ? nil : trimmed, for: definition.key, modifiers: flags)
+            }
+        }
+
+        let files = LocalFileSystem(context.applicationSettings)
+        MacroLoader(files).save(context.applicationSettings, macros: context.macros)
+        context.events2.echoText("Macros saved")
+
+        view.window?.close()
+    }
+
+    @objc private func cancel() {
+        view.window?.close()
+    }
+
+    // MARK: - NSTableViewDataSource
+
+    func numberOfRows(in _: NSTableView) -> Int {
+        keyDefinitions.count
+    }
+
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        guard row < keyDefinitions.count else {
+            return nil
+        }
+
+        let definition = keyDefinitions[row]
+
+        if tableColumn?.identifier == keyColumnIdentifier {
+            let view = tableView.makeView(withIdentifier: keyColumnIdentifier, owner: self) as? NSTableCellView ?? {
+                let cell = NSTableCellView()
+                let textField = NSTextField(labelWithString: "")
+                textField.translatesAutoresizingMaskIntoConstraints = false
+                cell.addSubview(textField)
+                cell.textField = textField
+
+                NSLayoutConstraint.activate([
+                    textField.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 4),
+                    textField.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -4),
+                    textField.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+                ])
+
+                cell.identifier = keyColumnIdentifier
+                return cell
+            }()
+
+            view.textField?.stringValue = definition.title
+            return view
+        }
+
+        let cell = tableView.makeView(withIdentifier: macroColumnIdentifier, owner: self) as? NSTableCellView ?? {
+            let cell = NSTableCellView()
+            let textField = NSTextField()
+            textField.translatesAutoresizingMaskIntoConstraints = false
+            textField.isEditable = true
+            textField.isBordered = false
+            textField.drawsBackground = false
+            textField.lineBreakMode = .byTruncatingTail
+            textField.delegate = self
+            cell.addSubview(textField)
+            cell.textField = textField
+            cell.identifier = macroColumnIdentifier
+
+            NSLayoutConstraint.activate([
+                textField.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 4),
+                textField.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -4),
+                textField.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+            ])
+
+            return cell
+        }()
+
+        if let store, store.isReserved(group: currentGroup, key: definition.key) {
+            cell.textField?.stringValue = store.reservedLabel(group: currentGroup, key: definition.key) ?? "Reserved"
+            cell.textField?.isEditable = false
+            cell.textField?.textColor = NSColor.secondaryLabelColor
+        } else if let store {
+            cell.textField?.isEditable = true
+            cell.textField?.isEnabled = true
+            cell.textField?.textColor = NSColor.labelColor
+            cell.textField?.stringValue = store.value(for: currentGroup, key: definition.key)
+        } else {
+            cell.textField?.stringValue = ""
+            cell.textField?.isEditable = false
+            cell.textField?.isEnabled = false
+        }
+
+        cell.textField?.tag = row
+        return cell
+    }
+
+    func tableView(_: NSTableView, shouldEdit _: NSTableColumn?, row: Int) -> Bool {
+        guard row < keyDefinitions.count else { return false }
+        guard let store else { return false }
+        return !store.isReserved(group: currentGroup, key: keyDefinitions[row].key)
+    }
+
+    // MARK: - NSTextFieldDelegate
+
+    func controlTextDidEndEditing(_ obj: Notification) {
+        guard let textField = obj.object as? NSTextField else { return }
+        let row = textField.tag
+        guard row >= 0, row < keyDefinitions.count else { return }
+        guard var store else { return }
+        let definition = keyDefinitions[row]
+        guard !store.isReserved(group: currentGroup, key: definition.key) else { return }
+
+        store.setValue(textField.stringValue, for: currentGroup, key: definition.key)
+        self.store = store
+        tableView.reloadData(forRowIndexes: IndexSet(integer: row), columnIndexes: IndexSet(integersIn: 0 ..< tableView.numberOfColumns))
+    }
+
+    // MARK: - Layout
+
+    private func setupUI() {
+        let modifierGroups = MacroModifierGroup.groups(for: category)
+        segmentedControl.isEnabled = !modifierGroups.isEmpty
+
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.hasVerticalScroller = true
+        scrollView.documentView = tableView
+
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.usesAlternatingRowBackgroundColors = true
+        tableView.rowHeight = 24
+        tableView.allowsColumnReordering = false
+        tableView.allowsColumnResizing = false
+
+        let keyColumn = NSTableColumn(identifier: keyColumnIdentifier)
+        keyColumn.title = "Key"
+        keyColumn.width = 100
+        tableView.addTableColumn(keyColumn)
+
+        let macroColumn = NSTableColumn(identifier: macroColumnIdentifier)
+        macroColumn.title = "Macro"
+        macroColumn.width = 360
+        tableView.addTableColumn(macroColumn)
+
+        footerLabel.translatesAutoresizingMaskIntoConstraints = false
+        infoLabel.translatesAutoresizingMaskIntoConstraints = false
+        okButton.translatesAutoresizingMaskIntoConstraints = false
+        cancelButton.translatesAutoresizingMaskIntoConstraints = false
+
+        let buttonStack = NSStackView(views: [cancelButton, okButton])
+        buttonStack.translatesAutoresizingMaskIntoConstraints = false
+        buttonStack.orientation = .horizontal
+        buttonStack.spacing = 8
+
+        view.addSubview(segmentedControl)
+        view.addSubview(scrollView)
+        view.addSubview(footerLabel)
+        view.addSubview(buttonStack)
+        view.addSubview(infoLabel)
+
+        if category == .function {
+            let popup = NSPopUpButton()
+            popup.translatesAutoresizingMaskIntoConstraints = false
+            popup.addItem(withTitle: "Macro Set 1")
+            popup.isEnabled = false
+            macroSetPopup = popup
+            view.addSubview(popup)
+
+            NSLayoutConstraint.activate([
+                popup.centerYAnchor.constraint(equalTo: buttonStack.centerYAnchor),
+                popup.trailingAnchor.constraint(equalTo: buttonStack.leadingAnchor, constant: -12),
+            ])
+        }
+
+        NSLayoutConstraint.activate([
+            segmentedControl.topAnchor.constraint(equalTo: view.topAnchor, constant: 16),
+            segmentedControl.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+
+            scrollView.topAnchor.constraint(equalTo: segmentedControl.bottomAnchor, constant: 12),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+
+            infoLabel.centerXAnchor.constraint(equalTo: scrollView.centerXAnchor),
+            infoLabel.centerYAnchor.constraint(equalTo: scrollView.centerYAnchor),
+            infoLabel.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor, constant: 20),
+            infoLabel.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor, constant: -20),
+
+            footerLabel.topAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: 12),
+            footerLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            footerLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+
+            buttonStack.topAnchor.constraint(equalTo: footerLabel.bottomAnchor, constant: 12),
+            buttonStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+            buttonStack.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -16),
+        ])
+
+        reloadData()
+    }
+}

--- a/docs/macro-preferences-spec.md
+++ b/docs/macro-preferences-spec.md
@@ -1,0 +1,104 @@
+# Outlander Macro Preferences UI Specification
+
+This document captures the requirements for rebuilding Outlander's macro
+preferences so they match the Avalon macOS client UX while fitting the existing
+Outlander data model (`MacroLoader`, `#macro` commands, `macros.cfg` files).
+
+## Menu Topology
+- Update `App → Settings` menu to match Avalon:
+  - `General Preferences…`
+  - `Highlights…`
+  - `Macros ▸` sub-menu with:
+    - `A–Z Macros`
+    - `Keypad Macros`
+    - `Function Macros`
+- Selecting any macro entry opens the corresponding editor window. The submenu
+  stays open to allow quick switching.
+- Keep “Choose Settings Directory…” elsewhere in the menu (current behaviour).
+
+## Shared Window Chrome
+- Each macro editor is a modal sheet or floating panel with:
+  - Title reflecting the category (`A–Z Macros`, `Keypad Macros`, `Function Macros`).
+  - Segmented control across the top for modifier groups (varies per category).
+  - Editable table view with two columns: `Key` (static label) and `Macro`
+    (editable text).
+  - Footer help text (identical wording across screens):
+    ```
+    \n - Send the command.  \p - Pause 1 second before continuing.
+    \x - Delete the contents of the command line before starting.
+    @  - Place the insertion marker here when done.
+    \? - Replace this with the contents of the command line before starting.
+    ```
+  - Primary button `OK` saves and dismisses. Provide `Cancel` if we choose a
+    non-modal window.
+- Reserved keys show `Reserved` in the Macro column and are read-only/greyed out.
+- Changes are stored in-memory immediately, persisted only when the user clicks
+  `OK`.
+
+## A–Z Macros Window
+- Keys: fixed list `A` … `Z` (26 rows).
+- Modifier segments: `Command`, `Option`, `Control`. Each segment displays the
+  macro assigned to `modifier + key`.
+- Reserved keys (per Avalon: B, C, etc.) must block edits; display “Reserved”.
+- Editing the Macro cell accepts plain text, supporting escape sequences listed
+  above. Empty string means “no macro”.
+- On save, apply changes to `GameContext.macros`, then call
+  `MacroLoader.save(...)` to update `macros.cfg`.
+
+## Keypad Macros Window
+- Keys: keypad `+`, `-`, `/`, `*`, digits `0–9`, `.`, and optionally `enter`,
+  `clear` if supported.
+- Modifier segments: `None`, `Command`, `Option`, `Control`, `Shift`.
+  - `None` shows macros for the unmodified key (movement commands in Avalon).
+  - Other segments show the modifier+key variations.
+- Macro column permits multiline sequences (entered using `\n`). Consider an
+  inline multi-line editor or accept literal `\n` tokens.
+- Saving mirrors the A–Z flow.
+
+## Function Macros Window
+- Keys: `Esc`, `F1`…`F12` (optionally extend to `F20` for full keyboards).
+- Modifier segments: `None`, `Command`, `Option`, `Control`, `Shift`.
+- Include a macro-set selector in the lower-right corner:
+  - Drop-down labeled “Macro Set 1” with stepper arrows to switch between sets.
+  - Support creating additional sets (e.g., “Macro Set 2”) and persisting each set
+    independently.
+  - Switching sets replaces the table contents with that set’s macros.
+- Same help footer as other windows.
+
+## Editing Workflow
+- Table allows inline edits; pressing Return commits the value.
+- Provide visual differentiation for populated rows (bold key label or icon).
+- Validate entries on save:
+  - Warn if an escape sequence uses an unknown flag.
+  - Prevent edits on reserved keys.
+- Offer optional `Revert`/`Cancel` to discard unsaved modifications.
+
+## Data Model & Persistence Updates
+- Extend `MacroLoader` and supporting structs to treat macros as:
+  - Category (A–Z, Keypad, Function).
+  - Modifier group (None/Command/Option/Control/Shift).
+  - Key identifier.
+  - Optional macro-set identifier (for Function Macros).
+- Maintain backwards compatibility with existing `#macro` syntax:
+  - Continue writing entries like `#macro {\u{2318}F1} {command}`.
+  - Introduce metadata for macro sets if required (e.g., grouping entries by set name).
+- Ensure UI updates trigger `MacroLoader.save(...)` so `#macro reload` and `#macro save`
+  still operate correctly.
+- After saving, re-register macros (`GameViewController.registerMacros`) so new
+  bindings take effect immediately.
+
+## Validation & UX Enhancements
+- Display status text showing count of defined macros in the active view/set.
+- Add search/filter box (optional, stretch goal).
+- Consider tooltip or popover explaining escape sequences on hover.
+- Log to the main window (`context.events2.echoText("Macros saved")`) when a save
+  succeeds, matching CLI command feedback.
+
+## Integration Checklist
+1. Build reusable view controller handling segmented modifiers, table editing,
+   and save/cancel.
+2. Wire new menu commands to present each window.
+3. Update `MacroLoader`/`GameContext` to expose data in a form convenient for the UI.
+4. Add unit tests covering load/save with modifiers, sets, and reserved keys.
+5. Confirm legacy `macros.cfg` loads without loss; verify upgraded file still
+   works with `#macro reload`.


### PR DESCRIPTION
- Added a Settings → Macros menu that opens dedicated editors for A–Z, Keypad, and Function macros.

- Implemented the shared MacroPreferences controller stack (segmented modifiers, editable table, reserved slots) plus MacroDefaults and loader support so new profiles seed keypad/sneak/familiar/function bindings automatically.

- Cleaned up the macro workflow documentation and ensured existing macros.cfg files remain backward compatible.